### PR TITLE
Mockito 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 8
+        java-version: 11
     - name: Build and Test
       run: sbt -v +test

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ ScalaTest + Mockito provides integration support between ScalaTest and Mockito.
 
 **Usage**
 
-To use it for ScalaTest 3.2.17 and Mockito 5.6.x: 
+To use it for ScalaTest 3.2.17 and Mockito 5.8.x: 
 
 SBT: 
 
 ```
-libraryDependencies += "org.scalatestplus" %% "mockito-5-6" % "3.2.17.0" % "test"
+libraryDependencies += "org.scalatestplus" %% "mockito-5-8" % "3.2.17.0" % "test"
 ```
 
 Maven: 
@@ -16,7 +16,7 @@ Maven:
 ```
 <dependency>
   <groupId>org.scalatestplus</groupId>
-  <artifactId>mockito-5-6_3</artifactId>
+  <artifactId>mockito-5-8_3</artifactId>
   <version>3.2.17.0</version>
   <scope>test</scope>
 </dependency>

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ ScalaTest + Mockito provides integration support between ScalaTest and Mockito.
 
 **Usage**
 
-To use it for ScalaTest 3.2.17 and Mockito 4.11.x: 
+To use it for ScalaTest 3.2.17 and Mockito 5.6.x: 
 
 SBT: 
 
 ```
-libraryDependencies += "org.scalatestplus" %% "mockito-4-11" % "3.2.17.0" % "test"
+libraryDependencies += "org.scalatestplus" %% "mockito-5-6" % "3.2.17.0" % "test"
 ```
 
 Maven: 
@@ -16,11 +16,14 @@ Maven:
 ```
 <dependency>
   <groupId>org.scalatestplus</groupId>
-  <artifactId>mockito-4-11_2.13</artifactId>
+  <artifactId>mockito-5-6_3</artifactId>
   <version>3.2.17.0</version>
   <scope>test</scope>
 </dependency>
 ```
+
+**Note**
+Mockito 5.x requires JDK11+, if you are on JDK8, please use `mockito-4-11` instead.
 
 **Publishing**
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.io.PrintWriter
 import scala.io.Source
 
-name := "mockito-5.6"
+name := "mockito-5.8"
 
 organization := "org.scalatestplus"
 
@@ -28,12 +28,12 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.18", "2.13.11", "3.1.3")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.18", "2.13.12", "3.1.3")
 
 libraryDependencies ++= Seq(
-  "org.mockito" % "mockito-core" % "5.6.0",
+  "org.mockito" % "mockito-core" % "5.8.0",
   "org.scalatest" %% "scalatest-core" % "3.2.17",
   "org.scalatest" %% "scalatest-funsuite" % "3.2.17" % "test"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import java.io.PrintWriter
 import scala.io.Source
 
-name := "mockito-4.11"
+name := "mockito-5.6"
 
 organization := "org.scalatestplus"
 
@@ -30,10 +30,10 @@ developers := List(
 
 scalaVersion := "2.13.11"
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.17", "2.13.11", "3.1.3")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.18", "2.13.11", "3.1.3")
 
 libraryDependencies ++= Seq(
-  "org.mockito" % "mockito-core" % "4.11.0",
+  "org.mockito" % "mockito-core" % "5.6.0",
   "org.scalatest" %% "scalatest-core" % "3.2.17",
   "org.scalatest" %% "scalatest-funsuite" % "3.2.17" % "test"
 )


### PR DESCRIPTION
Updated to use mockito 5.8.0, and added a note in README.md about the requirement for jdk11 for mockito 5.